### PR TITLE
change author position color to gray

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -974,9 +974,9 @@ div.twitter{
   }
 } 
 .author-position {
-  display:inline-block;
-  float:left;
-  color:$db-blue !important;
+  display: inline-block;
+  float: left;
+  color: gray;
   padding: { top:0.46rem; left:0.45rem;}
   font-size:1.3rem;
   font-family: 'Roboto Slab', serif !important;


### PR DESCRIPTION
The site uses DB Blue text to indicate links. `div.author-positiion` is not a link, so making it blue is confusing. Also, the `!important` was not necessary.

Before: 
![before](https://puu.sh/s0Mxg/a3133422e5.png)

After: 
![after](https://puu.sh/s0Myw/8252b07828.png)
