### PR TITLE
hide stuff for print media

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -1,0 +1,12 @@
+// hide a bunch of elements for printing
+a:after, #stickyheader, #stickyheader-small, #stickyalias, .below-header, .ssba, 
+.author-wrapper, #comment-policy, #disqus_thread, #sidebar-list, .db-footer 
+{
+    display: none;
+}
+
+div#stickyalias {
+    // need `visibility: hidden` instead of `display: none` for this one b/c
+    // the element has a JS-applied `display: block` inline style
+    visibility: hidden;
+}

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -1393,3 +1393,5 @@ margin-bottom: 0 !important;
 .f-search {
   text-align: center;
 }
+
+@import 'print';


### PR DESCRIPTION
cf. https://trello.com/c/fdhpdEoC/330-article-printing

This was as good as I could get without messing with the document structure. Notably couldn't hide the "Tweet" link or a weird divider image at the bottom; they're basically untargetable by CSS as the HTML is now.